### PR TITLE
Fetch all user channels returns 'channels' not 'user_channels'

### DIFF
--- a/lib/ex_twilio/resources/programmable_chat/user_channel.ex
+++ b/lib/ex_twilio/resources/programmable_chat/user_channel.ex
@@ -8,6 +8,7 @@ defmodule ExTwilio.ProgrammableChat.UserChannel do
   defstruct sid: nil,
             account_sid: nil,
             service_sid: nil,
+            channel_sid: nil,
             unread_messages_count: nil,
             last_consumed_message_index: nil,
             channel: nil,
@@ -20,6 +21,7 @@ defmodule ExTwilio.ProgrammableChat.UserChannel do
     ]
 
   def resource_name, do: "Channels"
+  def resource_collection_name, do: "channels"
 
   def parents,
     do: [


### PR DESCRIPTION
When fetching multiple resources from the Twilio API the name of the array in the response changes based on the resource being fetched. ExTwilio library infers the name from the elixir module that represents the API resource. In this case the UserChannel module infers the name is "user_channels" however when fetching all channels a user belongs to the array is labeled just "channels". See example response in Twilio API Docs: https://www.twilio.com/docs/chat/rest/user-channel-resource

We also need to add channel_sid to the UserChannels struct so it is populated in the returned struct when the response is parsed.